### PR TITLE
Accept floats with an exponent

### DIFF
--- a/src/parser/ply_grammar.rustpeg
+++ b/src/parser/ply_grammar.rustpeg
@@ -96,7 +96,7 @@ trimmed_line -> Line
 	/ v:property { Line::Property(v) }
 
 any_number -> String
-	= s:$([-+]? [0-9]+("."[0-9]+)?) { s.to_string() }
+	= s:$([-+]? [0-9]+("."[0-9]+)?("e"[-+]?[0-9]+)?) { s.to_string() }
 
 trimmed_data_line -> Vec<String>
 	= any_number ** space


### PR DESCRIPTION
I stumbled upon a PLY file that contained some floats with an exponent, so I modified the parser to accept them.