### PR TITLE
Update linked-hash-map to avoid UB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2018"
 travis-ci = { repository = "Fluci/ply-rs", branch = "master" }
 
 [dependencies]
-linked-hash-map = "^0.5.1"
+linked-hash-map = "^0.5.4"
 byteorder = "^1.2.7"
 peg = "^0.6.0"
 


### PR DESCRIPTION
I've been running into https://github.com/contain-rs/linked-hash-map/pull/106 while trying to get https://github.com/wahn/rs_pbrt. This PR updates `linked-hash-map` and fixes that issue.

```
thread 'main' panicked at 'attempted to leave type `linked_hash_map::Node<std::string::String, ply_rs::ply::ElementDef>` uninitialized, which is invalid', /rustc/2fd73fabe469357a12c2c974c140f67e7cdd76d0/library/core/src/mem/mod.rs:671:9
stack backtrace:
   0: rust_begin_unwind
             at /rustc/2fd73fabe469357a12c2c974c140f67e7cdd76d0/library/std/src/panicking.rs:493:5
   1: core::panicking::panic_fmt
             at /rustc/2fd73fabe469357a12c2c974c140f67e7cdd76d0/library/core/src/panicking.rs:92:14
   2: core::panicking::panic
             at /rustc/2fd73fabe469357a12c2c974c140f67e7cdd76d0/library/core/src/panicking.rs:50:5
   3: <linked_hash_map::LinkedHashMap<alloc::string::String,V> as ply_rs::ply::key_map::Addable<V>>::add
   4: rs_pbrt::shapes::plymesh::create_ply_mesh
   5: rs_pbrt::core::api::get_shapes_and_materials
   6: rs_pbrt::core::api::pbrt_shape
   7: rs_pbrt::parse_line
   8: rs_pbrt::parse_file
   9: rs_pbrt::main
```