### PR TITLE
Refactor: Change &String to &str for Efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ply-rs = "0.1.3"
 
 Add to your root:
 
-```rust
+```rust,no_run
 extern crate ply_rs;
 
 fn main() {}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -362,7 +362,7 @@ impl<E: PropertyAccess> Parser<E> {
         Ok(vals)
     }
     fn __read_ascii_property(&self, elem_iter: &mut Iter<String>, data_type: &PropertyType) -> Result<Property> {
-        let s : &String = match elem_iter.next() {
+        let s = match elem_iter.next() {
             None => return Err(io::Error::new(
                 ErrorKind::InvalidInput,
                 format!("Expected element of type '{:?}', but found nothing.", data_type)
@@ -411,7 +411,7 @@ impl<E: PropertyAccess> Parser<E> {
         where <D as FromStr>::Err: error::Error + marker::Send + marker::Sync + 'static {
         let mut list = Vec::<D>::new();
         for i in 0..count {
-            let s : &String = match elem_iter.next() {
+            let s = match elem_iter.next() {
                 None => return Err(io::Error::new(
                     ErrorKind::InvalidInput,
                     format!("Couldn't find a list element at index {}.", i)

--- a/src/ply/default_element.rs
+++ b/src/ply/default_element.rs
@@ -22,97 +22,97 @@ impl PropertyAccess for DefaultElement {
     fn set_property(&mut self, key: String, property: Property) {
         self.insert(key, property);
     }
-    fn get_char(&self, key: &String) -> Option<i8> {
+    fn get_char(&self, key: &str) -> Option<i8> {
         match *get!(self.get(key)) {
             Property::Char(x) => Some(x),
             _ => None,
         }
     }
-    fn get_uchar(&self, key: &String) -> Option<u8> {
+    fn get_uchar(&self, key: &str) -> Option<u8> {
         match *get!(self.get(key)) {
             Property::UChar(x) => Some(x),
             _ => None,
         }
     }
-    fn get_short(&self, key: &String) -> Option<i16> {
+    fn get_short(&self, key: &str) -> Option<i16> {
         match *get!(self.get(key)) {
             Property::Short(x) => Some(x),
             _ => None,
         }
     }
-    fn get_ushort(&self, key: &String) -> Option<u16> {
+    fn get_ushort(&self, key: &str) -> Option<u16> {
         match *get!(self.get(key)) {
             Property::UShort(x) => Some(x),
             _ => None,
         }
     }
-    fn get_int(&self, key: &String) -> Option<i32> {
+    fn get_int(&self, key: &str) -> Option<i32> {
         match *get!(self.get(key)) {
             Property::Int(x) => Some(x),
             _ => None,
         }
     }
-    fn get_uint(&self, key: &String) -> Option<u32> {
+    fn get_uint(&self, key: &str) -> Option<u32> {
         match *get!(self.get(key)) {
             Property::UInt(x) => Some(x),
             _ => None,
         }
     }
-    fn get_float(&self, key: &String) -> Option<f32> {
+    fn get_float(&self, key: &str) -> Option<f32> {
         match *get!(self.get(key)) {
             Property::Float(x) => Some(x),
             _ => None,
         }
     }
-    fn get_double(&self, key: &String) -> Option<f64> {
+    fn get_double(&self, key: &str) -> Option<f64> {
         match *get!(self.get(key)) {
             Property::Double(x) => Some(x),
             _ => None,
         }
     }
-    fn get_list_char(&self, key: &String) -> Option<&[i8]> {
+    fn get_list_char(&self, key: &str) -> Option<&[i8]> {
         match *get!(self.get(key)) {
             Property::ListChar(ref x) => Some(x),
             _ => None,
         }
     }
-    fn get_list_uchar(&self, key: &String) -> Option<&[u8]> {
+    fn get_list_uchar(&self, key: &str) -> Option<&[u8]> {
         match *get!(self.get(key)) {
             Property::ListUChar(ref x) => Some(x),
             _ => None,
         }
     }
-    fn get_list_short(&self, key: &String) -> Option<&[i16]> {
+    fn get_list_short(&self, key: &str) -> Option<&[i16]> {
         match *get!(self.get(key)) {
             Property::ListShort(ref x) => Some(x),
             _ => None,
         }
     }
-    fn get_list_ushort(&self, key: &String) -> Option<&[u16]> {
+    fn get_list_ushort(&self, key: &str) -> Option<&[u16]> {
         match *get!(self.get(key)) {
             Property::ListUShort(ref x) => Some(x),
             _ => None,
         }
     }
-    fn get_list_int(&self, key: &String) -> Option<&[i32]> {
+    fn get_list_int(&self, key: &str) -> Option<&[i32]> {
         match *get!(self.get(key)) {
             Property::ListInt(ref x) => Some(x),
             _ => None,
         }
     }
-    fn get_list_uint(&self, key: &String) -> Option<&[u32]> {
+    fn get_list_uint(&self, key: &str) -> Option<&[u32]> {
         match *get!(self.get(key)) {
             Property::ListUInt(ref x) => Some(x),
             _ => None,
         }
     }
-    fn get_list_float(&self, key: &String) -> Option<&[f32]> {
+    fn get_list_float(&self, key: &str) -> Option<&[f32]> {
         match *get!(self.get(key)) {
             Property::ListFloat(ref x) => Some(x),
             _ => None,
         }
     }
-    fn get_list_double(&self, key: &String) -> Option<&[f64]> {
+    fn get_list_double(&self, key: &str) -> Option<&[f64]> {
         match *get!(self.get(key)) {
             Property::ListDouble(ref x) => Some(x),
             _ => None,

--- a/src/ply/property.rs
+++ b/src/ply/property.rs
@@ -80,52 +80,52 @@ pub trait PropertyAccess {
         // By default, do nothing
         // Sombody might only want to write, no point in bothering him/her with setter implementations.
     }
-    fn get_char(&self, _property_name: &String) -> Option<i8> {
+    fn get_char(&self, _property_name: &str) -> Option<i8> {
         None
     }
-    fn get_uchar(&self, _property_name: &String) -> Option<u8> {
+    fn get_uchar(&self, _property_name: &str) -> Option<u8> {
         None
     }
-    fn get_short(&self, _property_name: &String) -> Option<i16> {
+    fn get_short(&self, _property_name: &str) -> Option<i16> {
         None
     }
-    fn get_ushort(&self, _property_name: &String) -> Option<u16> {
+    fn get_ushort(&self, _property_name: &str) -> Option<u16> {
         None
     }
-    fn get_int(&self, _property_name: &String) -> Option<i32> {
+    fn get_int(&self, _property_name: &str) -> Option<i32> {
         None
     }
-    fn get_uint(&self, _property_name: &String) -> Option<u32> {
+    fn get_uint(&self, _property_name: &str) -> Option<u32> {
         None
     }
-    fn get_float(&self, _property_name: &String) -> Option<f32> {
+    fn get_float(&self, _property_name: &str) -> Option<f32> {
         None
     }
-    fn get_double(&self, _property_name: &String) -> Option<f64> {
+    fn get_double(&self, _property_name: &str) -> Option<f64> {
         None
     }
-    fn get_list_char(&self, _property_name: &String) -> Option<&[i8]> {
+    fn get_list_char(&self, _property_name: &str) -> Option<&[i8]> {
         None
     }
-    fn get_list_uchar(&self, _property_name: &String) -> Option<&[u8]> {
+    fn get_list_uchar(&self, _property_name: &str) -> Option<&[u8]> {
         None
     }
-    fn get_list_short(&self, _property_name: &String) -> Option<&[i16]> {
+    fn get_list_short(&self, _property_name: &str) -> Option<&[i16]> {
         None
     }
-    fn get_list_ushort(&self, _property_name: &String) -> Option<&[u16]> {
+    fn get_list_ushort(&self, _property_name: &str) -> Option<&[u16]> {
         None
     }
-    fn get_list_int(&self, _property_name: &String) -> Option<&[i32]> {
+    fn get_list_int(&self, _property_name: &str) -> Option<&[i32]> {
         None
     }
-    fn get_list_uint(&self, _property_name: &String) -> Option<&[u32]> {
+    fn get_list_uint(&self, _property_name: &str) -> Option<&[u32]> {
         None
     }
-    fn get_list_float(&self, _property_name: &String) -> Option<&[f32]> {
+    fn get_list_float(&self, _property_name: &str) -> Option<&[f32]> {
         None
     }
-    fn get_list_double(&self, _property_name: &String) -> Option<&[f64]> {
+    fn get_list_double(&self, _property_name: &str) -> Option<&[f64]> {
         None
     }
 }


### PR DESCRIPTION
Updated references from &String to &str to improve efficiency and adhere to best practices in Rust. Since &str is the preferred way to pass string references, this change reduces unnecessary allocations and improves performance.

